### PR TITLE
MINIFI-57 Adjusting minifi-framework-nar dependencies

### DIFF
--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework-nar/pom.xml
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework-nar/pom.xml
@@ -34,6 +34,13 @@ limitations under the License.
         <source.skip>true</source.skip>
     </properties>
     <dependencies>
+
+        <!-- NiFi dependencies required by framework level components -->
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-nar-utils</artifactId>
+        </dependency>
+
         <!-- mark these nifi artifacts as provided since it is included in the lib -->
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -47,27 +54,7 @@ limitations under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-nar-utils</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-properties</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi.minifi</groupId>
-            <artifactId>minifi-framework-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-administration</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi.minifi</groupId>
-            <artifactId>minifi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -78,6 +65,18 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-framework-core-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- MiNiFi Dependencies -->
+        <dependency>
+            <groupId>org.apache.nifi.minifi</groupId>
+            <artifactId>minifi-framework-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi.minifi</groupId>
+            <artifactId>minifi-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
MINIFI-57 Adjusting minifi-framework-nar dependencies and migrating shared item to the framework NAR.

This is an initial solution to the extraneous WARN generated on startup.  Some of this will change pending the results of #43.
