### PR TITLE
MINIFI-125 Migrating the Bootstrap and Resources modules changes from NiFi 1.0 and 1.1

### DIFF
--- a/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/BootstrapCodec.java
+++ b/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/BootstrapCodec.java
@@ -85,7 +85,7 @@ public class BootstrapCodec {
 
                 final String secretKey = args[1];
 
-                runner.setNiFiCommandControlPort(port, secretKey);
+                runner.setMiNiFiCommandControlPort(port, secretKey);
                 writer.write("OK");
                 writer.newLine();
                 writer.flush();

--- a/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/RunMiNiFi.java
+++ b/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/RunMiNiFi.java
@@ -383,8 +383,10 @@ public class RunMiNiFi implements QueryableStatusAggregator, ConfigurationFileHo
 
         try {
             final Set<PosixFilePermission> perms = new HashSet<>();
-            perms.add(PosixFilePermission.OWNER_READ);
             perms.add(PosixFilePermission.OWNER_WRITE);
+            perms.add(PosixFilePermission.OWNER_READ);
+            perms.add(PosixFilePermission.GROUP_READ);
+            perms.add(PosixFilePermission.OTHERS_READ);
             Files.setPosixFilePermissions(statusFile.toPath(), perms);
         } catch (final Exception e) {
             logger.warn("Failed to set permissions so that only the owner can read status file {}; "

--- a/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/RunMiNiFi.java
+++ b/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/RunMiNiFi.java
@@ -291,7 +291,7 @@ public class RunMiNiFi implements QueryableStatusAggregator, ConfigurationFileHo
         return configFile;
     }
 
-    private File getBootstrapFile(final Logger logger, String directory, String defaultDirectory, String fileName) throws IOException{
+    private File getBootstrapFile(final Logger logger, String directory, String defaultDirectory, String fileName) throws IOException {
 
         final File confDir = bootstrapConfigFile.getParentFile();
         final File nifiHome = confDir.getParentFile();
@@ -300,9 +300,9 @@ public class RunMiNiFi implements QueryableStatusAggregator, ConfigurationFileHo
 
         final File fileDir;
 
-        if(confFileDir != null){
+        if (confFileDir != null) {
             fileDir = new File(confFileDir.trim());
-        } else{
+        } else {
             fileDir = new File(nifiHome, defaultDirectory);
         }
 
@@ -312,16 +312,16 @@ public class RunMiNiFi implements QueryableStatusAggregator, ConfigurationFileHo
         return statusFile;
     }
 
-    File getPidFile(final Logger logger) throws IOException{
-        return getBootstrapFile(logger, MINIFI_PID_DIR_PROP,DEFAULT_PID_DIR, MINIFI_PID_FILE_NAME);
+    File getPidFile(final Logger logger) throws IOException {
+        return getBootstrapFile(logger, MINIFI_PID_DIR_PROP, DEFAULT_PID_DIR, MINIFI_PID_FILE_NAME);
     }
 
-    File getStatusFile(final Logger logger) throws IOException{
-        return getBootstrapFile(logger, MINIFI_PID_DIR_PROP,DEFAULT_PID_DIR, MINIFI_STATUS_FILE_NAME);
+    File getStatusFile(final Logger logger) throws IOException {
+        return getBootstrapFile(logger, MINIFI_PID_DIR_PROP, DEFAULT_PID_DIR, MINIFI_STATUS_FILE_NAME);
     }
 
-    File getLockFile(final Logger logger) throws IOException{
-        return getBootstrapFile(logger, MINIFI_PID_DIR_PROP,DEFAULT_PID_DIR, MINIFI_LOCK_FILE_NAME);
+    File getLockFile(final Logger logger) throws IOException {
+        return getBootstrapFile(logger, MINIFI_PID_DIR_PROP, DEFAULT_PID_DIR, MINIFI_LOCK_FILE_NAME);
     }
 
     File getStatusFile() throws IOException{
@@ -556,7 +556,7 @@ public class RunMiNiFi implements QueryableStatusAggregator, ConfigurationFileHo
             return new Status(port, pid, true, true);
         }
 
-        final boolean alive = (pid == null) ? false : isProcessRunning(pid, logger);
+        final boolean alive = (pid != null) && isProcessRunning(pid, logger);
         return new Status(port, pid, pingSuccess, alive);
     }
 
@@ -801,7 +801,7 @@ public class RunMiNiFi implements QueryableStatusAggregator, ConfigurationFileHo
                 logger.error("Failed to send shutdown command to port {} due to {}. No PID found for the MiNiFi process, so unable to kill process; "
                     + "the process should be killed manually.", new Object[]{port, ioe.toString()});
             } else {
-                logger.error("Failed to send shutdown command to port {} due to {}. Will kill the MiNiFi Process with PID {}.", new Object[]{port, ioe.toString(), pid});
+                logger.error("Failed to send shutdown command to port {} due to {}. Will kill the MiNiFi Process with PID {}.", port, ioe.toString(), pid);
                 killProcessTree(pid, logger);
             }
         } finally {
@@ -1047,7 +1047,7 @@ public class RunMiNiFi implements QueryableStatusAggregator, ConfigurationFileHo
             builder.directory(workingDir);
         }
 
-        final String minifiLogDir = replaceNull(System.getProperty("org.apache.nifi.minifi.bootstrap.config.log.dir"),DEFAULT_LOG_DIR).trim();
+        final String minifiLogDir = replaceNull(System.getProperty("org.apache.nifi.minifi.bootstrap.config.log.dir"), DEFAULT_LOG_DIR).trim();
 
         final String libFilename = replaceNull(props.get("lib.dir"), "./lib").trim();
         File libDir = getFile(libFilename, workingDir);

--- a/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/ShutdownHook.java
+++ b/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/ShutdownHook.java
@@ -107,9 +107,13 @@ public class ShutdownHook extends Thread {
             }
         }
 
-        final File statusFile = runner.getStatusFile();
-        if (!statusFile.delete()) {
-            System.err.println("Failed to delete status file " + statusFile.getAbsolutePath() + "; this file should be cleaned up manually");
+        try {
+            final File statusFile = runner.getStatusFile();
+            if (!statusFile.delete()) {
+                System.err.println("Failed to delete status file " + statusFile.getAbsolutePath() + "; this file should be cleaned up manually");
+            }
+        }catch (IOException ex){
+            System.err.println("Failed to retrieve status file " + ex);
         }
 
         System.out.println("MiNiFi is done shutting down");

--- a/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/util/ConfigTransformer.java
+++ b/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/util/ConfigTransformer.java
@@ -167,6 +167,7 @@ public final class ConfigTransformer {
             writer.println();
             writer.println("nifi.version=" + NIFI_VERSION);
             writer.println("nifi.flow.configuration.file=./conf/flow.xml.gz");
+            writer.println("nifi.flow.configuration.archive.enabled=false");
             writer.println("nifi.flow.configuration.archive.dir=./conf/archive/");
             writer.println("nifi.flowcontroller.autoResumeState=true");
             writer.println("nifi.flowcontroller.graceful.shutdown.period=" + coreProperties.getFlowControllerGracefulShutdownPeriod());

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/dump-minifi.bat
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/dump-minifi.bat
@@ -16,6 +16,10 @@ rem    See the License for the specific language governing permissions and
 rem    limitations under the License.
 rem
 
+rem Set environment variables
+
+call minifi-env.bat
+
 rem Use JAVA_HOME if it's set; otherwise, just use java
 
 if "%JAVA_HOME%" == "" goto noJavaHome
@@ -38,7 +42,7 @@ set LIB_DIR=lib
 set CONF_DIR=conf
 
 set BOOTSTRAP_CONF_FILE=%CONF_DIR%\bootstrap.conf
-set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
+set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.log.dir=%NIFI_LOG_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.pid.dir=%NIFI_PID_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
 
 set JAVA_PARAMS=-cp %CONF_DIR%;%BOOTSTRAP_LIB_DIR%\*;%LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.minifi.bootstrap.RunMiNiFi
 set BOOTSTRAP_ACTION=dump

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/dump-minifi.bat
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/dump-minifi.bat
@@ -42,7 +42,7 @@ set LIB_DIR=lib
 set CONF_DIR=conf
 
 set BOOTSTRAP_CONF_FILE=%CONF_DIR%\bootstrap.conf
-set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.log.dir=%NIFI_LOG_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.pid.dir=%NIFI_PID_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
+set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.log.dir=%MINIFI_LOG_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.pid.dir=%MINIFI_PID_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
 
 set JAVA_PARAMS=-cp %CONF_DIR%;%BOOTSTRAP_LIB_DIR%\*;%LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.minifi.bootstrap.RunMiNiFi
 set BOOTSTRAP_ACTION=dump

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi-env.bat
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi-env.bat
@@ -1,0 +1,29 @@
+@echo off
+rem
+rem    Licensed to the Apache Software Foundation (ASF) under one or more
+rem    contributor license agreements.  See the NOTICE file distributed with
+rem    this work for additional information regarding copyright ownership.
+rem    The ASF licenses this file to You under the Apache License, Version 2.0
+rem    (the "License"); you may not use this file except in compliance with
+rem    the License.  You may obtain a copy of the License at
+rem
+rem       http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem    Unless required by applicable law or agreed to in writing, software
+rem    distributed under the License is distributed on an "AS IS" BASIS,
+rem    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem    See the License for the specific language governing permissions and
+rem    limitations under the License.
+rem
+
+
+rem The java implementation to use
+rem set JAVA_HOME="C:\Program Files\Java\jdk1.8.0"
+
+set MINIFI_ROOT=%~sdp0..\
+
+rem The directory for the NiFi pid file
+set MINIFI_PID_DIR=%MINIFI_ROOT%\run
+
+rem The directory for NiFi log files
+set MINIFI_LOG_DIR=%MINIFI_ROOT%\logs

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi-env.sh
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi-env.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# The java implementation to use.
+#export JAVA_HOME=/usr/java/jdk1.8.0/
+
+export MINIFI_HOME=$(cd "${SCRIPT_DIR}" && cd .. && pwd)
+
+#The directory for the NiFi pid file
+export MINIFI_PID_DIR="${MINIFI_HOME}/run"
+
+#The directory for NiFi log files
+export MINIFI_LOG_DIR="${MINIFI_HOME}/logs"

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
@@ -166,7 +166,7 @@ run() {
     MINIFI_LIBS="${MINIFI_HOME}/lib/*"
     BOOTSTRAP_LIBS="${MINIFI_HOME}/lib/bootstrap/*"
 
-    run_as=$(grep run.as "${BOOTSTRAP_CONF}" | cut -d'=' -f2)
+    run_as=$(grep '^\s*run.as' "${BOOTSTRAP_CONF}" | cut -d'=' -f2)
     # If the run as user is the same as that starting the process, ignore this configuration
     if [ "$run_as" = "$(whoami)" ]; then
         unset run_as

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
@@ -18,7 +18,30 @@
 
 # Script structure inspired from Apache Karaf and other Apache projects with similar startup approaches
 
-SCRIPT_DIR=$(dirname "$0")
+# Discover the path of the file
+
+
+# Since MacOS X, FreeBSD and some other systems lack gnu readlink, we use a more portable
+# approach based on following StackOverflow comment http://stackoverflow.com/a/1116890/888876
+
+TARGET_FILE=$0
+
+cd $(dirname $TARGET_FILE)
+TARGET_FILE=$(basename $TARGET_FILE)
+
+# Iterate down a (possible) chain of symlinks
+while [ -L "$TARGET_FILE" ]
+do
+    TARGET_FILE=$(readlink $TARGET_FILE)
+    cd $(dirname $TARGET_FILE)
+    TARGET_FILE=$(basename $TARGET_FILE)
+done
+
+# Compute the canonicalized name by finding the physical path
+# for the directory we're in and appending the target file.
+PHYS_DIR=`pwd -P`
+
+SCRIPT_DIR=$PHYS_DIR
 SCRIPT_NAME=$(basename "$0")
 PROGNAME=$(basename "$0")
 

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
@@ -229,6 +229,7 @@ run() {
     else
         (eval $RUN_MINIFI_CMD $@)
     fi
+    EXIT_STATUS=$?
 
     # Wait just a bit (3 secs) to wait for the logging to finish and then echo a new-line.
     # We do this to avoid having logs spewed on the console after running the command and then not giving
@@ -249,11 +250,13 @@ case "$1" in
         ;;
     start|stop|run|status|flowStatus|dump|env)
         main "$@"
+        exit $EXIT_STATUS
         ;;
     restart)
         init
-    run "stop"
-    run "start"
+        run "stop"
+        run "start"
+        exit $EXIT_STATUS
     ;;
     *)
         echo "Usage minifi {start|stop|run|restart|status|flowStatus|dump|install}"

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
@@ -220,7 +220,7 @@ run() {
 
     BOOTSTRAP_DIR_PARAMS="${BOOTSTRAP_LOG_PARAMS} ${BOOTSTRAP_PID_PARAMS} ${BOOTSTRAP_CONF_PARAMS}"
 
-    RUN_MINIFI_CMD="cd "\""${MINIFI_HOME}"\"" && ${sudo_cmd_prefix} "\""${JAVA}"\"" -cp "\""${BOOTSTRAP_CLASSPATH}"\"" -Xms12m -Xmx24m ${BOOTSTRAP_DIR_PARAMS}  org.apache.nifi.bootstrap.RunNiFi"
+    RUN_MINIFI_CMD="cd "\""${MINIFI_HOME}"\"" && ${sudo_cmd_prefix} "\""${JAVA}"\"" -cp "\""${BOOTSTRAP_CLASSPATH}"\"" -Xms12m -Xmx24m ${BOOTSTRAP_DIR_PARAMS}  org.apache.nifi.minifi.bootstrap.RunMiNiFi"
 
     # run 'start' in the background because the process will continue to run, monitoring MiNiFi.
     # all other commands will terminate quickly so want to just wait for them

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/minifi.sh
@@ -15,9 +15,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-# chkconfig: 2345 20 80
-# description: Apache NiFi - MiNiFi
-#
 
 # Script structure inspired from Apache Karaf and other Apache projects with similar startup approaches
 
@@ -143,22 +140,72 @@ init() {
 
 
 install() {
-        SVC_NAME=minifi
-        if [ "x$2" != "x" ] ; then
-                SVC_NAME=$2
-        fi
+   detectOS
 
-        SVC_FILE="/etc/init.d/${SVC_NAME}"
-        cp "$0" "${SVC_FILE}"
-        sed -i s:MINIFI_HOME=.*:MINIFI_HOME="${MINIFI_HOME}": "${SVC_FILE}"
-        sed -i s:PROGNAME=.*:PROGNAME="${SCRIPT_NAME}": "${SVC_FILE}"
-        rm -f "/etc/rc2.d/S65${SVC_NAME}"
-        ln -s "/etc/init.d/${SVC_NAME}" "/etc/rc2.d/S65${SVC_NAME}"
-        rm -f "/etc/rc2.d/K65${SVC_NAME}"
-        ln -s "/etc/init.d/${SVC_NAME}" "/etc/rc2.d/K65${SVC_NAME}"
-        echo "Service ${SVC_NAME} installed"
+    if [ "${darwin}" = "true"  ] || [ "${cygwin}" = "true" ]; then
+        echo 'Installing Apache MiNiFi as a service is not supported on OS X or Cygwin.'
+        exit 1
+    fi
+
+    SVC_NAME=minifi
+    if [ "x$2" != "x" ] ; then
+        SVC_NAME=$2
+    fi
+
+    initd_dir='/etc/init.d'
+    SVC_FILE="${initd_dir}/${SVC_NAME}"
+
+    if [ ! -w  "${initd_dir}" ]; then
+        echo "Current user does not have write permissions to ${initd_dir}. Cannot install MiNiFi as a service."
+        exit 1
+    fi
+
+# Create the init script, overwriting anything currently present
+cat <<SERVICEDESCRIPTOR > ${SVC_FILE}
+#!/bin/sh
+
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# chkconfig: 2345 20 80
+# description: Apache NiFi is a dataflow system based on the principles of Flow-Based Programming.
+#
+
+# Make use of the configured NIFI_HOME directory and pass service requests to the nifi.sh executable
+MINIFI_HOME=${MINIFI_HOME}
+bin_dir=\${MINIFI_HOME}/bin
+minifi_executable=\${bin_dir}/minifi.sh
+
+\${minifi_executable} "\$@"
+SERVICEDESCRIPTOR
+
+    if [ ! -f "${SVC_FILE}" ]; then
+        echo "Could not create service file ${SVC_FILE}"
+        exit 1
+    fi
+
+    # Provide the user execute access on the file
+    chmod u+x ${SVC_FILE}
+
+    rm -f "/etc/rc2.d/S65${SVC_NAME}"
+    ln -s "/etc/init.d/${SVC_NAME}" "/etc/rc2.d/S65${SVC_NAME}" || { echo "Could not create link /etc/rc2.d/S65${SVC_NAME}"; exit 1; }
+    rm -f "/etc/rc2.d/K65${SVC_NAME}"
+    ln -s "/etc/init.d/${SVC_NAME}" "/etc/rc2.d/K65${SVC_NAME}" || { echo "Could not create link /etc/rc2.d/K65${SVC_NAME}"; exit 1; }
+    echo "Service ${SVC_NAME} installed"
 }
-
 
 run() {
     BOOTSTRAP_CONF_DIR="${MINIFI_HOME}/conf"

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/run-minifi.bat
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/run-minifi.bat
@@ -16,6 +16,10 @@ rem    See the License for the specific language governing permissions and
 rem    limitations under the License.
 rem
 
+rem Set environment variables
+
+call minifi-env.bat
+
 rem Use JAVA_HOME if it's set; otherwise, just use java
 
 if "%JAVA_HOME%" == "" goto noJavaHome
@@ -38,7 +42,7 @@ set LIB_DIR=lib
 set CONF_DIR=conf
 
 set BOOTSTRAP_CONF_FILE=%CONF_DIR%\bootstrap.conf
-set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
+set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.log.dir=%NIFI_LOG_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.pid.dir=%NIFI_PID_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
 
 set JAVA_PARAMS=-cp %CONF_DIR%;%BOOTSTRAP_LIB_DIR%\*;%LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.minifi.bootstrap.RunMiNiFi
 set BOOTSTRAP_ACTION=run

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/run-minifi.bat
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/run-minifi.bat
@@ -42,7 +42,7 @@ set LIB_DIR=lib
 set CONF_DIR=conf
 
 set BOOTSTRAP_CONF_FILE=%CONF_DIR%\bootstrap.conf
-set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.log.dir=%NIFI_LOG_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.pid.dir=%NIFI_PID_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
+set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.log.dir=%MINIFI_LOG_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.pid.dir=%MINIFI_PID_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
 
 set JAVA_PARAMS=-cp %CONF_DIR%;%BOOTSTRAP_LIB_DIR%\*;%LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.minifi.bootstrap.RunMiNiFi
 set BOOTSTRAP_ACTION=run

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/status-minifi.bat
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/status-minifi.bat
@@ -16,6 +16,8 @@ rem    See the License for the specific language governing permissions and
 rem    limitations under the License.
 rem
 
+call minifi-env.bat
+
 rem Use JAVA_HOME if it's set; otherwise, just use java
 
 if "%JAVA_HOME%" == "" goto noJavaHome
@@ -38,7 +40,7 @@ set LIB_DIR=lib
 set CONF_DIR=conf
 
 set BOOTSTRAP_CONF_FILE=%CONF_DIR%\bootstrap.conf
-set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
+set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.log.dir=%NIFI_LOG_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.pid.dir=%NIFI_PID_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
 
 set JAVA_PARAMS=-cp %CONF_DIR%;%BOOTSTRAP_LIB_DIR%\*;%LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.minifi.bootstrap.RunMiNiFi
 set BOOTSTRAP_ACTION=status

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/status-minifi.bat
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/bin/status-minifi.bat
@@ -40,7 +40,7 @@ set LIB_DIR=lib
 set CONF_DIR=conf
 
 set BOOTSTRAP_CONF_FILE=%CONF_DIR%\bootstrap.conf
-set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.log.dir=%NIFI_LOG_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.pid.dir=%NIFI_PID_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
+set JAVA_ARGS=-Dorg.apache.nifi.minifi.bootstrap.config.log.dir=%MINIFI_LOG_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.pid.dir=%MINIFI_PID_DIR% -Dorg.apache.nifi.minifi.bootstrap.config.file=%BOOTSTRAP_CONF_FILE%
 
 set JAVA_PARAMS=-cp %CONF_DIR%;%BOOTSTRAP_LIB_DIR%\*;%LIB_DIR%\* -Xms12m -Xmx24m %JAVA_ARGS% org.apache.nifi.minifi.bootstrap.RunMiNiFi
 set BOOTSTRAP_ACTION=status

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
@@ -20,7 +20,7 @@
     </contextListener>
     
     <appender name="APP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/minifi-app.log</file>
+        <file>${org.apache.nifi.minifi.bootstrap.config.log.dir}/minifi-app.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <!--
               For daily rollover, use 'app_%d.log'.
@@ -28,7 +28,7 @@
               To GZIP rolled files, replace '.log' with '.log.gz'.
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
-            <fileNamePattern>./logs/minifi-app_%d{yyyy-MM-dd_HH}.%i.log.gz</fileNamePattern>
+            <fileNamePattern>${org.apache.nifi.minifi.bootstrap.config.log.dir}/minifi-app_%d{yyyy-MM-dd_HH}.%i.log.gz</fileNamePattern>
             <!-- Keep 10 rolling periods worth of log files-->
             <maxHistory>10</maxHistory>
             <!-- Max size each log file will be-->
@@ -47,7 +47,7 @@
     </appender>
 
     <appender name="BOOTSTRAP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/minifi-bootstrap.log</file>
+        <file>${org.apache.nifi.minifi.bootstrap.config.log.dir}/minifi-bootstrap.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!--
               For daily rollover, use 'user_%d.log'.
@@ -55,7 +55,7 @@
               To GZIP rolled files, replace '.log' with '.log.gz'.
               To ZIP rolled files, replace '.log' with '.log.zip'.
             -->
-            <fileNamePattern>./logs/minifi-bootstrap_%d.log.gz</fileNamePattern>
+            <fileNamePattern>${org.apache.nifi.minifi.bootstrap.config.log.dir}/minifi-bootstrap_%d.log.gz</fileNamePattern>
             <!-- Keep 5 rolling periods worth of logs-->
             <maxHistory>5</maxHistory>
         </rollingPolicy>

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/src/main/resources/conf/logback.xml
@@ -73,6 +73,8 @@
     <!-- valid logging levels: TRACE, DEBUG, INFO, WARN, ERROR -->
     
     <logger name="org.apache.nifi" level="INFO"/>
+    <logger name="org.apache.nifi.processors" level="WARN"/>
+    <logger name="org.apache.nifi.processors.standard.LogAttribute" level="INFO"/>
     <logger name="org.apache.nifi.controller.repository.StandardProcessSession" level="WARN" />
 
     <!-- Logger for managing logging statements for jetty -->


### PR DESCRIPTION
This does not include the changes for: variable registry and encrypted properties. Both are much bigger efforts that deserve their own ticket.

Also this does not include PR 1092 due to the issue found with it (NIFI-3112)