### PR TITLE
MINIFI-170 Change FlowStatusReport to be JSON

### DIFF
--- a/minifi-commons/minifi-utils/pom.xml
+++ b/minifi-commons/minifi-utils/pom.xml
@@ -15,6 +15,12 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
     <parent>
         <groupId>org.apache.nifi.minifi</groupId>
         <artifactId>minifi-commons</artifactId>

--- a/minifi-commons/minifi-utils/pom.xml
+++ b/minifi-commons/minifi-utils/pom.xml
@@ -15,12 +15,6 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
-    </dependencies>
     <parent>
         <groupId>org.apache.nifi.minifi</groupId>
         <artifactId>minifi-commons</artifactId>
@@ -29,6 +23,11 @@
 
     <artifactId>minifi-utils</artifactId>
     <packaging>jar</packaging>
-
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/minifi-commons/minifi-utils/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
+++ b/minifi-commons/minifi-utils/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
@@ -116,20 +116,14 @@ public class FlowStatusReport implements java.io.Serializable {
 
         FlowStatusReport that = (FlowStatusReport) o;
 
-        if (getControllerServiceStatusList() != null ? !getControllerServiceStatusList().equals(that.getControllerServiceStatusList()) : that.getControllerServiceStatusList() != null)
-            return false;
-        if (getProcessorStatusList() != null ? !getProcessorStatusList().equals(that.getProcessorStatusList()) : that.getProcessorStatusList() != null)
-            return false;
-        if (getConnectionStatusList() != null ? !getConnectionStatusList().equals(that.getConnectionStatusList()) : that.getConnectionStatusList() != null)
-            return false;
+        if (getControllerServiceStatusList() != null ? !getControllerServiceStatusList().equals(that.getControllerServiceStatusList()) : that.getControllerServiceStatusList() != null) return false;
+        if (getProcessorStatusList() != null ? !getProcessorStatusList().equals(that.getProcessorStatusList()) : that.getProcessorStatusList() != null) return false;
+        if (getConnectionStatusList() != null ? !getConnectionStatusList().equals(that.getConnectionStatusList()) : that.getConnectionStatusList() != null) return false;
         if (getRemoteProcessGroupStatusList() != null ? !getRemoteProcessGroupStatusList().equals(that.getRemoteProcessGroupStatusList()) : that.getRemoteProcessGroupStatusList() != null)
             return false;
-        if (getInstanceStatus() != null ? !getInstanceStatus().equals(that.getInstanceStatus()) : that.getInstanceStatus() != null)
-            return false;
-        if (getSystemDiagnosticsStatus() != null ? !getSystemDiagnosticsStatus().equals(that.getSystemDiagnosticsStatus()) : that.getSystemDiagnosticsStatus() != null)
-            return false;
-        if (getReportingTaskStatusList() != null ? !getReportingTaskStatusList().equals(that.getReportingTaskStatusList()) : that.getReportingTaskStatusList() != null)
-            return false;
+        if (getInstanceStatus() != null ? !getInstanceStatus().equals(that.getInstanceStatus()) : that.getInstanceStatus() != null) return false;
+        if (getSystemDiagnosticsStatus() != null ? !getSystemDiagnosticsStatus().equals(that.getSystemDiagnosticsStatus()) : that.getSystemDiagnosticsStatus() != null) return false;
+        if (getReportingTaskStatusList() != null ? !getReportingTaskStatusList().equals(that.getReportingTaskStatusList()) : that.getReportingTaskStatusList() != null) return false;
         return getErrorsGeneratingReport() != null ? getErrorsGeneratingReport().equals(that.getErrorsGeneratingReport()) : that.getErrorsGeneratingReport() == null;
 
     }

--- a/minifi-commons/minifi-utils/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
+++ b/minifi-commons/minifi-utils/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
@@ -17,6 +17,9 @@
 
 package org.apache.nifi.minifi.commons.status;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.nifi.minifi.commons.status.connection.ConnectionStatusBean;
 import org.apache.nifi.minifi.commons.status.controllerservice.ControllerServiceStatus;
 import org.apache.nifi.minifi.commons.status.instance.InstanceStatus;
@@ -25,6 +28,8 @@ import org.apache.nifi.minifi.commons.status.reportingTask.ReportingTaskStatus;
 import org.apache.nifi.minifi.commons.status.rpg.RemoteProcessGroupStatusBean;
 import org.apache.nifi.minifi.commons.status.system.SystemDiagnosticsStatus;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.List;
 
 public class FlowStatusReport implements java.io.Serializable {
@@ -36,6 +41,7 @@ public class FlowStatusReport implements java.io.Serializable {
     private SystemDiagnosticsStatus systemDiagnosticsStatus;
     private List<ReportingTaskStatus> reportingTaskStatusList;
     private List<String> errorsGeneratingReport;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     public FlowStatusReport() {
     }
@@ -111,14 +117,20 @@ public class FlowStatusReport implements java.io.Serializable {
 
         FlowStatusReport that = (FlowStatusReport) o;
 
-        if (getControllerServiceStatusList() != null ? !getControllerServiceStatusList().equals(that.getControllerServiceStatusList()) : that.getControllerServiceStatusList() != null) return false;
-        if (getProcessorStatusList() != null ? !getProcessorStatusList().equals(that.getProcessorStatusList()) : that.getProcessorStatusList() != null) return false;
-        if (getConnectionStatusList() != null ? !getConnectionStatusList().equals(that.getConnectionStatusList()) : that.getConnectionStatusList() != null) return false;
+        if (getControllerServiceStatusList() != null ? !getControllerServiceStatusList().equals(that.getControllerServiceStatusList()) : that.getControllerServiceStatusList() != null)
+            return false;
+        if (getProcessorStatusList() != null ? !getProcessorStatusList().equals(that.getProcessorStatusList()) : that.getProcessorStatusList() != null)
+            return false;
+        if (getConnectionStatusList() != null ? !getConnectionStatusList().equals(that.getConnectionStatusList()) : that.getConnectionStatusList() != null)
+            return false;
         if (getRemoteProcessGroupStatusList() != null ? !getRemoteProcessGroupStatusList().equals(that.getRemoteProcessGroupStatusList()) : that.getRemoteProcessGroupStatusList() != null)
             return false;
-        if (getInstanceStatus() != null ? !getInstanceStatus().equals(that.getInstanceStatus()) : that.getInstanceStatus() != null) return false;
-        if (getSystemDiagnosticsStatus() != null ? !getSystemDiagnosticsStatus().equals(that.getSystemDiagnosticsStatus()) : that.getSystemDiagnosticsStatus() != null) return false;
-        if (getReportingTaskStatusList() != null ? !getReportingTaskStatusList().equals(that.getReportingTaskStatusList()) : that.getReportingTaskStatusList() != null) return false;
+        if (getInstanceStatus() != null ? !getInstanceStatus().equals(that.getInstanceStatus()) : that.getInstanceStatus() != null)
+            return false;
+        if (getSystemDiagnosticsStatus() != null ? !getSystemDiagnosticsStatus().equals(that.getSystemDiagnosticsStatus()) : that.getSystemDiagnosticsStatus() != null)
+            return false;
+        if (getReportingTaskStatusList() != null ? !getReportingTaskStatusList().equals(that.getReportingTaskStatusList()) : that.getReportingTaskStatusList() != null)
+            return false;
         return getErrorsGeneratingReport() != null ? getErrorsGeneratingReport().equals(that.getErrorsGeneratingReport()) : that.getErrorsGeneratingReport() == null;
 
     }
@@ -138,7 +150,24 @@ public class FlowStatusReport implements java.io.Serializable {
 
     @Override
     public String toString() {
-        return "FlowStatusReport{" +
+
+        StringWriter jsonString = new StringWriter();
+        try(JsonGenerator generator = objectMapper.getFactory().createGenerator(jsonString)){
+            generator.writeStartObject();
+            generator.writeObjectField("controllerServiceStatusList", controllerServiceStatusList);
+            generator.writeObjectField("processorStatusList", processorStatusList);
+            generator.writeObjectField("connectionStatusList", connectionStatusList);
+            generator.writeObjectField("remoteProcessGroupStatusList", remoteProcessGroupStatusList);
+            generator.writeObjectField("instanceStatus", instanceStatus);
+            generator.writeObjectField("systemDiagnosticsStatus", systemDiagnosticsStatus);
+            generator.writeObjectField("reportingTaskStatusList", reportingTaskStatusList);
+            generator.writeObjectField("errorsGeneratingReport", errorsGeneratingReport);
+            generator.writeEndObject();
+            generator.close();
+        } catch (IOException e) {
+            //this should not occur since we are using a StringWriter, however, in the event it does. Generate
+            //the old style report
+            return "FlowStatusReport{" +
                 "controllerServiceStatusList=" + controllerServiceStatusList +
                 ", processorStatusList=" + processorStatusList +
                 ", connectionStatusList=" + connectionStatusList +
@@ -148,5 +177,7 @@ public class FlowStatusReport implements java.io.Serializable {
                 ", reportingTaskStatusList=" + reportingTaskStatusList +
                 ", errorsGeneratingReport=" + errorsGeneratingReport +
                 '}';
+        }
+        return jsonString.toString();
     }
 }

--- a/minifi-commons/minifi-utils/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
+++ b/minifi-commons/minifi-utils/src/main/java/org/apache/nifi/minifi/commons/status/FlowStatusReport.java
@@ -17,7 +17,6 @@
 
 package org.apache.nifi.minifi.commons.status;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.nifi.minifi.commons.status.connection.ConnectionStatusBean;

--- a/minifi-docs/src/main/markdown/System_Admin_Guide.md
+++ b/minifi-docs/src/main/markdown/System_Admin_Guide.md
@@ -314,8 +314,7 @@ MiNiFi home: /Users/user/projects/nifi-minifi/minifi-assembly/target/minifi-0.0.
 
 Bootstrap Config File: /Users/user/projects/nifi-minifi/minifi-assembly/target/minifi-0.0.1-SNAPSHOT-bin/minifi-0.0.1-SNAPSHOT/conf/bootstrap.conf
 
-FlowStatusReport{controllerServiceStatusList=null, processorStatusList=[{name='TailFile', processorHealth={runStatus='Running', hasBulletins=false, validationErrorList=[]}, processorStats=null,
-bulletinList=null}], connectionStatusList=null, remoteProcessGroupStatusList=null, instanceStatus=null, systemDiagnosticsStatus=null, reportingTaskStatusList=null, errorsGeneratingReport=[]}
+{"controllerServiceStatusList":null,"processorStatusList":[{"name":"Connection Diagnostics","processorHealth":{"runStatus":"Running","hasBulletins":false,"validationErrorList":[]},"processorStats":null,"bulletinList":null},{"name":"UpdateAttribute","processorHealth":{"runStatus":"Running","hasBulletins":false,"validationErrorList":[]},"processorStats":null,"bulletinList":null},{"name":"Processor Diagnostics","processorHealth":{"runStatus":"Running","hasBulletins":false,"validationErrorList":[]},"processorStats":null,"bulletinList":null},{"name":"System Diagnostics","processorHealth":{"runStatus":"Running","hasBulletins":false,"validationErrorList":[]},"processorStats":null,"bulletinList":null},{"name":"GenerateFlowFile","processorHealth":{"runStatus":"Running","hasBulletins":false,"validationErrorList":[]},"processorStats":null,"bulletinList":null}],"connectionStatusList":null,"remoteProcessGroupStatusList":null,"instanceStatus":null,"systemDiagnosticsStatus":null,"reportingTaskStatusList":null,"errorsGeneratingReport":[]}
 ```
 
 # Periodic Status Reporters


### PR DESCRIPTION
The FlowStatus report were in a format that is close to but not JSON.

FlowStatusReport{controllerServiceStatusList=null, processorStatusList=[{name='GenerateFlowFile', processorHealth={runStatus='Running', hasBulletins=false, validationErrorList=[]}, processorStats={activeThreads=0, flowfilesReceived=0, bytesRead=0, bytesWritten=1024000, flowfilesSent=0, invocations=100, processingNanos=106080516}, bulletinList=[]}], connectionStatusList=null, remoteProcessGroupStatusList=null, instanceStatus=null, systemDiagnosticsStatus=null, reportingTaskStatusList=null, errorsGeneratingReport=[]}

This makes it hard to process. The changes in this P/R result in a FlowStatus report that is valid JSON, thus enabling standard tools to be used to process the reports. 
