### PR TITLE
MINIFI-403 - Adjusting included NiFi dependencies

### DIFF
--- a/minifi-assembly/pom.xml
+++ b/minifi-assembly/pom.xml
@@ -142,20 +142,10 @@ limitations under the License.
             <version>0.2.1-SNAPSHOT</version>
         </dependency>
 
-        <!-- MiNiFi NiFi Dependencies -->
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-processor-utils</artifactId>
-        </dependency>
-
         <!-- NiFi Assembly Dependencies-->
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-ssl-context-service-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
@@ -186,10 +176,6 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-persistent-provenance-repository</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-distributed-cache-client-service-api</artifactId>
         </dependency>
 
         <!-- Provided in NiFi so must include here too -->

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework-nar/pom.xml
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework-nar/pom.xml
@@ -43,6 +43,12 @@ limitations under the License.
             <artifactId>minifi-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
+            <type>nar</type>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- NiFi Framework level dependencies -->
         <dependency>

--- a/minifi-nar-bundles/minifi-standard-nar/pom.xml
+++ b/minifi-nar-bundles/minifi-standard-nar/pom.xml
@@ -33,13 +33,18 @@ limitations under the License.
     <dependencies>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-standard-services-api-nar</artifactId>
-            <type>nar</type>
+            <artifactId>nifi-standard-processors</artifactId>
+            <version>${org.apache.nifi.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>
-            <artifactId>nifi-standard-processors</artifactId>
-            <version>${org.apache.nifi.version}</version>
+            <artifactId>nifi-distributed-cache-client-service-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.nifi</groupId>
+            <artifactId>nifi-standard-services-api-nar</artifactId>
+            <type>nar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.nifi</groupId>


### PR DESCRIPTION
MINIFI-403 - Adjusting included NiFi dependencies and remove those API JARs that were treated as System bundles preventing dependent NARs from finding a compatible API NAR.