### PR TITLE
MINIFI-353 Adjusting GID to be the same as the default in the Docker Maven Dockerfile

### DIFF
--- a/minifi-docker/dockerhub/Dockerfile
+++ b/minifi-docker/dockerhub/Dockerfile
@@ -20,7 +20,7 @@ FROM openjdk:8-jre-alpine
 MAINTAINER Apache MiNiFi <dev@nifi.apache.org>
 
 ARG UID=1000
-ARG GID=50
+ARG GID=1000
 ARG MINIFI_VERSION=0.2.0
 
 ENV MINIFI_BASE_DIR /opt/minifi


### PR DESCRIPTION
MINIFI-353 Adjusting GID to be the same as the default in the Docker Maven Dockerfile and remove GID '50' already exists warning.