### PR TITLE
MINIFI-412 Upgrading commons-daemon to 1.1.0 and making use of a mirror

### DIFF
--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/pom.xml
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/pom.xml
@@ -53,19 +53,19 @@
 									<else>
 										<echo message="Downloading Commons Daemon Windows binaries." />
 										<get
-											src="http://www.apache.org/dist/commons/daemon/binaries/windows/commons-daemon-1.0.15-bin-windows.zip"
-											dest="${java.io.tmpdir}/commons-daemon-1.0.15-bin-windows.zip"
+											src="http://apache.claz.org/commons/daemon/binaries/windows/commons-daemon-1.1.0-bin-windows.zip"
+											dest="${java.io.tmpdir}/commons-daemon-1.1.0-bin-windows.zip"
 											skipexisting="true" />
 										<local name="checksum.matches" />
-										<property name="sha256sum" value="f46d87be0997b5c0f5c3a340ee8addca04cb2a32b2dc3e3a9e89a592ccf6abed" />
-										<checksum file="${java.io.tmpdir}/commons-daemon-1.0.15-bin-windows.zip" algorithm="SHA-256" property="${sha256sum}" verifyProperty="checksum.matches"/>
+										<property name="sha256sum" value="b5a211f826dc4c0d90508eb1222fe00d70c04a960a6c06540b13ccc5ca71d377" />
+										<checksum file="${java.io.tmpdir}/commons-daemon-1.1.0-bin-windows.zip" algorithm="SHA-256" property="${sha256sum}" verifyProperty="checksum.matches"/>
 										<echo message="Checksum match = ${checksum.matches}"/>
 										<condition property="checksum.matches.fail">
       										<equals arg1="${checksum.matches}" arg2="false"/>
       									</condition>
       									<fail if="checksum.matches.fail">Checksum error</fail>
 										<unzip
-											src="${java.io.tmpdir}/commons-daemon-1.0.15-bin-windows.zip"
+											src="${java.io.tmpdir}/commons-daemon-1.1.0-bin-windows.zip"
 											dest="${java.io.tmpdir}" />
 										<copy file="${java.io.tmpdir}/prunmgr.exe"
 											tofile="${basedir}/src/main/resources/bin/minifiw.exe" />


### PR DESCRIPTION
MINIFI-412 Upgrading commons-daemon to 1.1.0 and making use of a mirror instead of Apache dist.

Thank you for submitting a contribution to Apache NiFi - MiNiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi-minifi folder?
- [-] Have you written or updated unit tests to verify your changes?
- [- ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the LICENSE file, including the main LICENSE file under minifi-assembly?
- [-] If applicable, have you updated the NOTICE file, including the main NOTICE file found under minifi-assembly?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
