### PR TITLE
MINIFI-416 Adjusting Docker based integration tests to run with Alpine based images

### DIFF
--- a/minifi-c2/minifi-c2-docker/dockerhub/DockerBuild.sh
+++ b/minifi-c2/minifi-c2-docker/dockerhub/DockerBuild.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
+#!/bin/sh
 
 DOCKER_UID=1000
 if [ -n "$1" ]; then

--- a/minifi-c2/minifi-c2-docker/dockerhub/DockerRun.sh
+++ b/minifi-c2/minifi-c2-docker/dockerhub/DockerRun.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
+#!/bin/sh
 DOCKER_IMAGE="$(egrep -v '(^#|^\s*$|^\s*\t*#)' DockerImage.txt)"
 echo "Running Docker Image: $DOCKER_IMAGE"
 docker run -it -d $DOCKER_IMAGE

--- a/minifi-c2/minifi-c2-integration-tests/pom.xml
+++ b/minifi-c2/minifi-c2-integration-tests/pom.xml
@@ -56,7 +56,7 @@ limitations under the License.
         <dependency>
             <groupId>com.palantir.docker.compose</groupId>
             <artifactId>docker-compose-rule-junit4</artifactId>
-            <version>0.31.1</version>
+            <version>0.33.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/minifi-docker/dockerhub/DockerBuild.sh
+++ b/minifi-docker/dockerhub/DockerBuild.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
+#!/bin/sh
 
 DOCKER_UID=1000
 if [ -n "$1" ]; then

--- a/minifi-docker/dockerhub/DockerRun.sh
+++ b/minifi-docker/dockerhub/DockerRun.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
+#!/bin/sh
 DOCKER_IMAGE="$(egrep -v '(^#|^\s*$|^\s*\t*#)' DockerImage.txt)"
 echo "Running Docker Image: $DOCKER_IMAGE"
 docker run -it -d $DOCKER_IMAGE

--- a/minifi-integration-tests/pom.xml
+++ b/minifi-integration-tests/pom.xml
@@ -40,7 +40,7 @@ limitations under the License.
         <dependency>
             <groupId>com.palantir.docker.compose</groupId>
             <artifactId>docker-compose-rule-junit4</artifactId>
-            <version>0.31.1</version>
+            <version>0.33.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -91,6 +91,7 @@ limitations under the License.
                 <filtering>true</filtering>
                 <includes>
                     <include>docker-compose-*.yml</include>
+                    <include>Dockerfile.*.test</include>
                 </includes>
             </testResource>
             <testResource>
@@ -98,6 +99,7 @@ limitations under the License.
                 <filtering>false</filtering>
                 <excludes>
                     <exclude>docker-compose-*.yml</exclude>
+                    <exclude>Dockerfile.*.test</exclude>
                 </excludes>
             </testResource>
         </testResources>

--- a/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/c2/HierarchicalC2IntegrationTest.java
+++ b/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/c2/HierarchicalC2IntegrationTest.java
@@ -99,7 +99,7 @@ public class HierarchicalC2IntegrationTest {
         docker.after();
     }
 
-    @Test(timeout = 120_000)
+    @Test(timeout = 180_000)
     public void testMiNiFiEdge1() throws Exception {
         LogUtil.verifyLogEntries("c2/hierarchical/minifi-edge1/expected.json", docker.containers().container("minifi-edge1"));
         Path csvToJsonDir = resourceDirectory.resolve("standalone").resolve("v1").resolve("CsvToJson").resolve("yml");
@@ -107,7 +107,7 @@ public class HierarchicalC2IntegrationTest {
         LogUtil.verifyLogEntries("standalone/v1/CsvToJson/yml/expected.json", docker.containers().container("minifi-edge1"));
     }
 
-    @Test(timeout = 120_000)
+    @Test(timeout = 180_000)
     public void testMiNiFiEdge2() throws Exception {
         LogUtil.verifyLogEntries("c2/hierarchical/minifi-edge2/expected.json", docker.containers().container("minifi-edge2"));
         Path csvToJsonDir = resourceDirectory.resolve("standalone").resolve("v1").resolve("CsvToJson").resolve("yml");
@@ -115,7 +115,7 @@ public class HierarchicalC2IntegrationTest {
         LogUtil.verifyLogEntries("standalone/v1/CsvToJson/yml/expected.json", docker.containers().container("minifi-edge2"));
     }
 
-    @Test(timeout = 120_000)
+    @Test(timeout = 180_000)
     public void testMiNiFiEdge3() throws Exception {
         LogUtil.verifyLogEntries("c2/hierarchical/minifi-edge3/expected.json", docker.containers().container("minifi-edge3"));
         Path csvToJsonDir = resourceDirectory.resolve("standalone").resolve("v1").resolve("CsvToJson").resolve("yml");

--- a/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/util/LogUtil.java
+++ b/minifi-integration-tests/src/test/java/org/apache/nifi/minifi/integration/util/LogUtil.java
@@ -45,6 +45,7 @@ public class LogUtil {
             expectedLogEntries = expected.stream().map(map -> new ExpectedLogEntry(Pattern.compile((String)map.get("pattern")), (int) map.getOrDefault("occurrences", 1))).collect(Collectors.toList());
         }
         DockerPort dockerPort = container.port(8000);
+        logger.info("Connecting to external port {} for docker internal port of {}", new Object[]{dockerPort.getExternalPort(), dockerPort.getInternalPort()});
         URL url = new URL("http://" + dockerPort.getIp() + ":" + dockerPort.getExternalPort());
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
         try (InputStream inputStream = urlConnection.getInputStream();

--- a/minifi-integration-tests/src/test/resources/Dockerfile.minifi.test
+++ b/minifi-integration-tests/src/test/resources/Dockerfile.minifi.test
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM apacheminifi:${minifi.version}
+
+USER root
+
+RUN apk update \
+    && apk add python
+
+USER minifi

--- a/minifi-integration-tests/src/test/resources/Dockerfile.minific2.test
+++ b/minifi-integration-tests/src/test/resources/Dockerfile.minific2.test
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM apacheminific2:${minifi.version}
+
+USER root
+
+RUN apk update \
+    && apk add python
+
+USER c2

--- a/minifi-integration-tests/src/test/resources/docker-compose-c2-hierarchical.yml
+++ b/minifi-integration-tests/src/test/resources/docker-compose-c2-hierarchical.yml
@@ -17,7 +17,10 @@ version: "2"
 
 services:
   c2-authoritative:
-    image: apacheminific2:${minifi.c2.version}
+    build:
+      context: ./
+      dockerfile: Dockerfile.minific2.test
+    image: apacheminific2-test
     ports:
       - "10443"
     hostname: c2-authoritative
@@ -36,7 +39,10 @@ services:
       - edge1
 
   minifi-edge1:
-    image: apacheminifi:${minifi.version}
+    build:
+      context: ./
+      dockerfile: ./Dockerfile.minifi.test
+    image: apacheminifi-test
     ports:
       - "8000"
     volumes:
@@ -48,14 +54,17 @@ services:
       - ./certificates-c2-hierarchical/minifi-edge1/keystore.jks:/opt/minifi/minifi-${minifi.version}/conf/keystore.jks
       - ./certificates-c2-hierarchical/minifi-edge1/truststore.jks:/opt/minifi/minifi-${minifi.version}/conf/truststore.jks
     entrypoint:
-      - bash
+      - sh
       - -c
       - /opt/minifi/minifi-${minifi.version}/bin/minifi.sh start && python /home/minifi/tailFileServer.py --file /opt/minifi/minifi-${minifi.version}/logs/minifi-app.log --file /opt/minifi/minifi-${minifi.version}/logs/minifi-bootstrap.log
     networks:
       - edge1
 
   c2-edge2:
-    image: apacheminific2:${minifi.c2.version}
+    build:
+      context: ./
+      dockerfile: Dockerfile.minific2.test
+    image: apacheminific2-test
     ports:
       - "10080"
     hostname: c2-edge2
@@ -70,7 +79,10 @@ services:
       - edge2
 
   minifi-edge2:
-    image: apacheminifi:${minifi.version}
+    build:
+      context: ./
+      dockerfile: Dockerfile.minifi.test
+    image: apacheminifi-test
     ports:
       - "8000"
     volumes:
@@ -79,7 +91,7 @@ services:
       - ./c2/hierarchical/minifi-edge2/bootstrap.conf:/opt/minifi/minifi-${minifi.version}/conf/bootstrap.conf
       - ./logback.xml:/opt/minifi/minifi-${minifi.version}/conf/logback.xml
     entrypoint:
-      - bash
+      - sh
       - -c
       - /opt/minifi/minifi-${minifi.version}/bin/minifi.sh start && python /home/minifi/tailFileServer.py --file /opt/minifi/minifi-${minifi.version}/logs/minifi-app.log --file /opt/minifi/minifi-${minifi.version}/logs/minifi-bootstrap.log
     networks:
@@ -97,7 +109,10 @@ services:
       - edge3
 
   minifi-edge3:
-    image: apacheminifi:${minifi.version}
+    build:
+      context: ./
+      dockerfile: Dockerfile.minifi.test
+    image: apacheminifi-test
     ports:
       - "8000"
     volumes:
@@ -109,7 +124,7 @@ services:
       - ./certificates-c2-hierarchical/minifi-edge3/keystore.jks:/opt/minifi/minifi-${minifi.version}/conf/keystore.jks
       - ./certificates-c2-hierarchical/minifi-edge3/truststore.jks:/opt/minifi/minifi-${minifi.version}/conf/truststore.jks
     entrypoint:
-      - bash
+      - sh
       - -c
       - /opt/minifi/minifi-${minifi.version}/bin/minifi.sh start && python /home/minifi/tailFileServer.py --file /opt/minifi/minifi-${minifi.version}/logs/minifi-app.log --file /opt/minifi/minifi-${minifi.version}/logs/minifi-bootstrap.log
     networks:

--- a/minifi-integration-tests/src/test/resources/docker-compose-v1-standalone.yml
+++ b/minifi-integration-tests/src/test/resources/docker-compose-v1-standalone.yml
@@ -17,7 +17,10 @@ version: "2"
 
 services:
   minifi:
-    image: apacheminifi:${minifi.version}
+    build:
+      context: ./
+      dockerfile: Dockerfile.minifi.test
+    image: apacheminifi-test
     ports:
       - "8000"
     hostname: minifi
@@ -28,6 +31,6 @@ services:
       - ./logback.xml:/opt/minifi/minifi-${minifi.version}/conf/logback.xml
       - REPLACED_WITH_CONFIG_FILE:/opt/minifi/minifi-${minifi.version}/conf/config.yml
     entrypoint:
-      - bash
+      - sh
       - -c
       - /opt/minifi/minifi-${minifi.version}/bin/minifi.sh start && python /home/minifi/tailFileServer.py --file /opt/minifi/minifi-${minifi.version}/logs/minifi-app.log


### PR DESCRIPTION
MINIFI-416 Adjusting Docker based integration tests to run with the conversion of images to use the Alpine based base image.

Thank you for submitting a contribution to Apache NiFi - MiNiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi-minifi folder?
- [X] Have you written or updated unit tests to verify your changes?
