### PR TITLE
MINIFI-420 Migrate Windows service executable handling to minifi-assembly

### DIFF
--- a/minifi-assembly/pom.xml
+++ b/minifi-assembly/pom.xml
@@ -28,6 +28,52 @@ limitations under the License.
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>ant-contrib</groupId>
+                        <artifactId>ant-contrib</artifactId>
+                        <version>20020829</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>download-commons-daemon</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                                <if>
+                                    <available file="${basedir}/target/minifiw.exe" />
+                                    <then>
+                                        <echo message="Skipping download of commons-daemon." />
+                                    </then>
+                                    <else>
+                                        <echo message="Downloading Commons Daemon Windows binaries." />
+                                        <get src="http://apache.claz.org/commons/daemon/binaries/windows/commons-daemon-1.1.0-bin-windows.zip" dest="${java.io.tmpdir}/commons-daemon-1.1.0-bin-windows.zip" skipexisting="true" />
+                                        <local name="checksum.matches" />
+                                        <property name="sha256sum" value="b5a211f826dc4c0d90508eb1222fe00d70c04a960a6c06540b13ccc5ca71d377" />
+                                        <checksum file="${java.io.tmpdir}/commons-daemon-1.1.0-bin-windows.zip" algorithm="SHA-256" property="${sha256sum}" verifyProperty="checksum.matches" />
+                                        <echo message="Checksum match = ${checksum.matches}" />
+                                        <condition property="checksum.matches.fail">
+                                            <equals arg1="${checksum.matches}" arg2="false" />
+                                        </condition>
+                                        <fail if="checksum.matches.fail">Checksum error</fail>
+                                        <unzip src="${java.io.tmpdir}/commons-daemon-1.1.0-bin-windows.zip" dest="${java.io.tmpdir}" />
+                                        <copy file="${java.io.tmpdir}/prunmgr.exe" tofile="${basedir}/target/minifiw.exe" />
+                                        <copy file="${java.io.tmpdir}/amd64/prunsrv.exe" tofile="${basedir}/target/minifi.exe" />
+                                    </else>
+                                </if>
+                            </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <finalName>minifi-${project.version}</finalName>

--- a/minifi-assembly/src/main/assembly/dependencies.xml
+++ b/minifi-assembly/src/main/assembly/dependencies.xml
@@ -136,6 +136,17 @@
     </dependencySets>
     <files>
         <file>
+            <source>./target/minifi.exe</source>
+            <outputDirectory>./bin</outputDirectory>
+            <filtered>false</filtered>
+        </file>
+        <file>
+            <source>./target/minifiw.exe</source>
+            <outputDirectory>./bin</outputDirectory>
+            <filtered>false</filtered>
+        </file>
+
+        <file>
             <source>./README.md</source>
             <outputDirectory>./</outputDirectory>
             <destName>README</destName>

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/pom.xml
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-resources/pom.xml
@@ -25,58 +25,6 @@
     <description>holds common resources used to build installers</description>
     <build>
         <plugins>
-        	<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<dependencies>
-					<dependency>
-						<groupId>ant-contrib</groupId>
-						<artifactId>ant-contrib</artifactId>
-						<version>20020829</version>
-					</dependency>
-				</dependencies>
-				<executions>
-					<execution>
-						<id>download-commons-daemon</id>
-						<phase>compile</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<tasks>
-								<taskdef resource="net/sf/antcontrib/antcontrib.properties" />
-								<if>
-									<available file="${basedir}/src/main/resources/bin/minifiw.exe" />
-									<then>
-										<echo message="Skipping download of commons-daemon." />
-									</then>
-									<else>
-										<echo message="Downloading Commons Daemon Windows binaries." />
-										<get
-											src="http://apache.claz.org/commons/daemon/binaries/windows/commons-daemon-1.1.0-bin-windows.zip"
-											dest="${java.io.tmpdir}/commons-daemon-1.1.0-bin-windows.zip"
-											skipexisting="true" />
-										<local name="checksum.matches" />
-										<property name="sha256sum" value="b5a211f826dc4c0d90508eb1222fe00d70c04a960a6c06540b13ccc5ca71d377" />
-										<checksum file="${java.io.tmpdir}/commons-daemon-1.1.0-bin-windows.zip" algorithm="SHA-256" property="${sha256sum}" verifyProperty="checksum.matches"/>
-										<echo message="Checksum match = ${checksum.matches}"/>
-										<condition property="checksum.matches.fail">
-      										<equals arg1="${checksum.matches}" arg2="false"/>
-      									</condition>
-      									<fail if="checksum.matches.fail">Checksum error</fail>
-										<unzip
-											src="${java.io.tmpdir}/commons-daemon-1.1.0-bin-windows.zip"
-											dest="${java.io.tmpdir}" />
-										<copy file="${java.io.tmpdir}/prunmgr.exe"
-											tofile="${basedir}/src/main/resources/bin/minifiw.exe" />
-                    <copy file="${java.io.tmpdir}/amd64/prunsrv.exe" tofile="${basedir}/src/main/resources/bin/minifi.exe" />
-									</else>
-								</if>
-							</tasks>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
MINIFI-420 Migrate Windows service executable handling to minifi-assembly to avoid executables in source packages.

Thank you for submitting a contribution to Apache NiFi - MiNiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi-minifi folder?
- [-] Have you written or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the LICENSE file, including the main LICENSE file under minifi-assembly?
- [-] If applicable, have you updated the NOTICE file, including the main NOTICE file found under minifi-assembly?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
