### PR TITLE
MINIFI-421 Updating MiNiFi to make use of NiFi 1.5 libraries

### DIFF
--- a/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/RunMiNiFi.java
+++ b/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/RunMiNiFi.java
@@ -24,14 +24,14 @@ import org.apache.nifi.minifi.bootstrap.configuration.ConfigurationChangeListene
 import org.apache.nifi.minifi.bootstrap.status.PeriodicStatusReporter;
 import org.apache.nifi.minifi.bootstrap.util.ConfigTransformer;
 import org.apache.nifi.minifi.commons.status.FlowStatusReport;
-import org.apache.nifi.stream.io.ByteArrayInputStream;
-import org.apache.nifi.stream.io.ByteArrayOutputStream;
 import org.apache.nifi.util.Tuple;
 import org.apache.nifi.util.file.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/MiNiFiServer.java
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-framework-core/src/main/java/org/apache/nifi/minifi/MiNiFiServer.java
@@ -52,6 +52,8 @@ public class MiNiFiServer {
     private FlowService flowService;
     private FlowController flowController;
 
+    private static final String DEFAULT_SENSITIVE_PROPS_KEY = "nififtw!";
+
     /**
      *
      * @param props the configuration
@@ -87,7 +89,12 @@ public class MiNiFiServer {
                     // do nothing
                 }
             };
-            StringEncryptor encryptor = StringEncryptor.createEncryptor(props);
+
+            final String sensitivePropAlgorithmVal = props.getProperty(StringEncryptor.NF_SENSITIVE_PROPS_ALGORITHM);
+            final String sensitivePropProviderVal = props.getProperty(StringEncryptor.NF_SENSITIVE_PROPS_PROVIDER);
+            final String sensitivePropValueNifiPropVar = props.getProperty(StringEncryptor.NF_SENSITIVE_PROPS_KEY, DEFAULT_SENSITIVE_PROPS_KEY);
+
+            StringEncryptor encryptor = StringEncryptor.createEncryptor(sensitivePropAlgorithmVal, sensitivePropProviderVal, sensitivePropValueNifiPropVar);
             VariableRegistry variableRegistry = new FileBasedVariableRegistry(props.getVariableRegistryPropertiesPaths());
             BulletinRepository bulletinRepository = new VolatileBulletinRepository();
 
@@ -98,7 +105,8 @@ public class MiNiFiServer {
                     auditService,
                     encryptor,
                     bulletinRepository,
-                    variableRegistry
+                    variableRegistry,
+                    null
                     );
 
             flowService = StandardFlowService.createStandaloneInstance(

--- a/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-nar-utils/src/main/java/org/apache/nifi/mock/MockReportingInitializationContext.java
+++ b/minifi-nar-bundles/minifi-framework-bundle/minifi-framework/minifi-nar-utils/src/main/java/org/apache/nifi/mock/MockReportingInitializationContext.java
@@ -17,6 +17,7 @@
 package org.apache.nifi.mock;
 
 import org.apache.nifi.controller.ControllerServiceLookup;
+import org.apache.nifi.controller.NodeTypeProvider;
 import org.apache.nifi.logging.ComponentLog;
 import org.apache.nifi.reporting.ReportingInitializationContext;
 import org.apache.nifi.scheduling.SchedulingStrategy;
@@ -78,6 +79,11 @@ public class MockReportingInitializationContext implements ReportingInitializati
 
     @Override
     public File getKerberosConfigurationFile() {
+        return null;
+    }
+
+    @Override
+    public NodeTypeProvider getNodeTypeProvider() {
         return null;
     }
 }

--- a/minifi-toolkit/minifi-toolkit-configuration/src/main/java/org/apache/nifi/minifi/toolkit/configuration/dto/RemotePortSchemaFunction.java
+++ b/minifi-toolkit/minifi-toolkit-configuration/src/main/java/org/apache/nifi/minifi/toolkit/configuration/dto/RemotePortSchemaFunction.java
@@ -17,6 +17,7 @@
 
 package org.apache.nifi.minifi.toolkit.configuration.dto;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.nifi.minifi.commons.schema.RemotePortSchema;
 import org.apache.nifi.minifi.commons.schema.common.CommonPropertyKeys;
 import org.apache.nifi.web.api.dto.RemoteProcessGroupPortDTO;
@@ -32,7 +33,9 @@ public class RemotePortSchemaFunction implements Function<RemoteProcessGroupPort
     @Override
     public RemotePortSchema apply(RemoteProcessGroupPortDTO remoteProcessGroupPortDTO) {
         Map<String, Object> map = new HashMap<>();
-        map.put(ID_KEY, remoteProcessGroupPortDTO.getId());
+        // If a targetId is specified, it takes precedence over the original id
+        final String targetId = remoteProcessGroupPortDTO.getTargetId();
+        map.put(ID_KEY, StringUtils.isNotBlank(targetId) ? targetId : remoteProcessGroupPortDTO.getId());
         map.put(NAME_KEY, remoteProcessGroupPortDTO.getName());
 
         map.put(CommonPropertyKeys.COMMENT_KEY, remoteProcessGroupPortDTO.getComments());

--- a/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/ConfigMainTest.java
+++ b/minifi-toolkit/minifi-toolkit-configuration/src/test/java/org/apache/nifi/minifi/toolkit/configuration/ConfigMainTest.java
@@ -168,6 +168,10 @@ public class ConfigMainTest {
     }
 
     @Test
+    public void testTransformRoundTrip15RPGHandling() throws IOException, JAXBException, SchemaLoaderException {
+        transformRoundTrip("1.5_RPG_Handling");
+    }
+    @Test
     public void testTransformRoundTripDecompression() throws IOException, JAXBException, SchemaLoaderException {
         transformRoundTrip("DecompressionCircularFlow");
     }

--- a/minifi-toolkit/minifi-toolkit-configuration/src/test/resources/1.5_RPG_Handling.xml
+++ b/minifi-toolkit/minifi-toolkit-configuration/src/test/resources/1.5_RPG_Handling.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" ?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ -->
+
+<template encoding-version="1.2">
+  <description></description>
+  <groupId>b8c22bdc-0160-1000-5e40-cc895080bf30</groupId>
+  <name>1.5 RPG Handling</name>
+  <snippet>
+    <connections>
+      <id>89b6b729-aa58-32f5-0000-000000000000</id>
+      <parentGroupId>108e0f24-3b43-34fb-0000-000000000000</parentGroupId>
+      <backPressureDataSizeThreshold>1 GB</backPressureDataSizeThreshold>
+      <backPressureObjectThreshold>10000</backPressureObjectThreshold>
+      <destination>
+        <groupId>9abd6b8c-816a-3f66-0000-000000000000</groupId>
+        <id>178e0a53-d8e9-3e33-a9d8-4949c4a3b805</id>
+        <type>REMOTE_INPUT_PORT</type>
+      </destination>
+      <flowFileExpiration>0 sec</flowFileExpiration>
+      <labelIndex>1</labelIndex>
+      <name></name>
+      <selectedRelationships>success</selectedRelationships>
+      <source>
+        <groupId>108e0f24-3b43-34fb-0000-000000000000</groupId>
+        <id>d80d4090-c56d-33ab-0000-000000000000</id>
+        <type>PROCESSOR</type>
+      </source>
+      <zIndex>0</zIndex>
+    </connections>
+    <processors>
+      <id>d80d4090-c56d-33ab-0000-000000000000</id>
+      <parentGroupId>108e0f24-3b43-34fb-0000-000000000000</parentGroupId>
+      <position>
+        <x>0.0</x>
+        <y>9.838514449178149</y>
+      </position>
+      <bundle>
+        <artifact>nifi-standard-nar</artifact>
+        <group>org.apache.nifi</group>
+        <version>1.5.0-SNAPSHOT</version>
+      </bundle>
+      <config>
+        <bulletinLevel>WARN</bulletinLevel>
+        <comments></comments>
+        <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+        <descriptors>
+          <entry>
+            <key>File Size</key>
+            <value>
+              <name>File Size</name>
+            </value>
+          </entry>
+          <entry>
+            <key>Batch Size</key>
+            <value>
+              <name>Batch Size</name>
+            </value>
+          </entry>
+          <entry>
+            <key>Data Format</key>
+            <value>
+              <name>Data Format</name>
+            </value>
+          </entry>
+          <entry>
+            <key>Unique FlowFiles</key>
+            <value>
+              <name>Unique FlowFiles</name>
+            </value>
+          </entry>
+          <entry>
+            <key>generate-ff-custom-text</key>
+            <value>
+              <name>generate-ff-custom-text</name>
+            </value>
+          </entry>
+          <entry>
+            <key>character-set</key>
+            <value>
+              <name>character-set</name>
+            </value>
+          </entry>
+        </descriptors>
+        <executionNode>ALL</executionNode>
+        <lossTolerant>false</lossTolerant>
+        <penaltyDuration>30 sec</penaltyDuration>
+        <properties>
+          <entry>
+            <key>File Size</key>
+            <value>1 kB</value>
+          </entry>
+          <entry>
+            <key>Batch Size</key>
+            <value>1</value>
+          </entry>
+          <entry>
+            <key>Data Format</key>
+            <value>Text</value>
+          </entry>
+          <entry>
+            <key>Unique FlowFiles</key>
+            <value>false</value>
+          </entry>
+          <entry>
+            <key>generate-ff-custom-text</key>
+          </entry>
+          <entry>
+            <key>character-set</key>
+            <value>UTF-8</value>
+          </entry>
+        </properties>
+        <runDurationMillis>0</runDurationMillis>
+        <schedulingPeriod>1 sec</schedulingPeriod>
+        <schedulingStrategy>TIMER_DRIVEN</schedulingStrategy>
+        <yieldDuration>1 sec</yieldDuration>
+      </config>
+      <name>GenerateFlowFile</name>
+      <relationships>
+        <autoTerminate>false</autoTerminate>
+        <name>success</name>
+      </relationships>
+      <state>RUNNING</state>
+      <style></style>
+      <type>org.apache.nifi.processors.standard.GenerateFlowFile</type>
+    </processors>
+    <remoteProcessGroups>
+      <id>9abd6b8c-816a-3f66-0000-000000000000</id>
+      <parentGroupId>108e0f24-3b43-34fb-0000-000000000000</parentGroupId>
+      <position>
+        <x>573.6607153753321</x>
+        <y>0.0</y>
+      </position>
+      <communicationsTimeout>30 sec</communicationsTimeout>
+      <contents>
+        <inputPorts>
+          <comments></comments>
+          <concurrentlySchedulableTaskCount>1</concurrentlySchedulableTaskCount>
+          <connected>true</connected>
+          <exists>true</exists>
+          <id>178e0a53-d8e9-3e33-a9d8-4949c4a3b805</id>
+          <name>From instance</name>
+          <targetId>d7c01635-0160-1000-68aa-fd8a4f9d168e</targetId>
+          <targetRunning>true</targetRunning>
+          <transmitting>true</transmitting>
+          <useCompression>false</useCompression>
+        </inputPorts>
+      </contents>
+      <proxyHost></proxyHost>
+      <proxyUser></proxyUser>
+      <targetUri>http://localhost:8080/nifi</targetUri>
+      <targetUris>http://localhost:8080/nifi</targetUris>
+      <transportProtocol>RAW</transportProtocol>
+      <yieldDuration>10 sec</yieldDuration>
+    </remoteProcessGroups>
+  </snippet>
+  <timestamp>01/03/2018 10:26:57 EST</timestamp>
+</template>

--- a/minifi-toolkit/minifi-toolkit-configuration/src/test/resources/1.5_RPG_Handling.yml
+++ b/minifi-toolkit/minifi-toolkit-configuration/src/test/resources/1.5_RPG_Handling.yml
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the \"License\"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+MiNiFi Config Version: 3
+Flow Controller:
+  name: 1.5 RPG Handling
+  comment: ''
+Core Properties:
+  flow controller graceful shutdown period: 10 sec
+  flow service write delay interval: 500 ms
+  administrative yield duration: 30 sec
+  bored yield duration: 10 millis
+  max concurrent threads: 1
+  variable registry properties: ''
+FlowFile Repository:
+  partitions: 256
+  checkpoint interval: 2 mins
+  always sync: false
+  Swap:
+    threshold: 20000
+    in period: 5 sec
+    in threads: 1
+    out period: 5 sec
+    out threads: 4
+Content Repository:
+  content claim max appendable size: 10 MB
+  content claim max flow files: 100
+  always sync: false
+Provenance Repository:
+  provenance rollover time: 1 min
+  implementation: org.apache.nifi.provenance.MiNiFiPersistentProvenanceRepository
+Component Status Repository:
+  buffer size: 1440
+  snapshot frequency: 1 min
+Security Properties:
+  keystore: ''
+  keystore type: ''
+  keystore password: ''
+  key password: ''
+  truststore: ''
+  truststore type: ''
+  truststore password: ''
+  ssl protocol: ''
+  Sensitive Props:
+    key:
+    algorithm: PBEWITHMD5AND256BITAES-CBC-OPENSSL
+    provider: BC
+Processors:
+- id: d80d4090-c56d-33ab-0000-000000000000
+  name: GenerateFlowFile
+  class: org.apache.nifi.processors.standard.GenerateFlowFile
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 1 sec
+  penalization period: 30 sec
+  yield period: 1 sec
+  run duration nanos: 0
+  auto-terminated relationships list: []
+  Properties:
+    Batch Size: '1'
+    Data Format: Text
+    File Size: 1 kB
+    Unique FlowFiles: 'false'
+    character-set: UTF-8
+    generate-ff-custom-text:
+Controller Services: []
+Process Groups: []
+Input Ports: []
+Output Ports: []
+Funnels: []
+Connections:
+- id: 89b6b729-aa58-32f5-0000-000000000000
+  name: GenerateFlowFile/success/d7c01635-0160-1000-68aa-fd8a4f9d168e
+  source id: d80d4090-c56d-33ab-0000-000000000000
+  source relationship names:
+  - success
+  destination id: d7c01635-0160-1000-68aa-fd8a4f9d168e
+  max work queue size: 10000
+  max work queue data size: 1 GB
+  flowfile expiration: 0 sec
+  queue prioritizer class: ''
+Remote Process Groups:
+- id: 9abd6b8c-816a-3f66-0000-000000000000
+  name: ''
+  url: http://localhost:8080/nifi
+  comment: ''
+  timeout: 30 sec
+  yield period: 10 sec
+  transport protocol: RAW
+  proxy host: ''
+  proxy port: ''
+  proxy user: ''
+  proxy password: ''
+  local network interface: ''
+  Input Ports:
+  - id: d7c01635-0160-1000-68aa-fd8a4f9d168e
+    name: From instance
+    comment: ''
+    max concurrent tasks: 1
+    use compression: false
+  Output Ports: []
+NiFi Properties Overrides: {}

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ limitations under the License.
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <inceptionYear>2016</inceptionYear>
         <org.slf4j.version>1.7.25</org.slf4j.version>
-        <org.apache.nifi.version>1.4.0</org.apache.nifi.version>
+        <org.apache.nifi.version>1.5.0</org.apache.nifi.version>
         <logback.version>1.2.3</logback.version>
         <jetty.version>9.4.3.v20170317</jetty.version>
         <jersey.version>1.19</jersey.version>


### PR DESCRIPTION
MINIFI-421 Updating MiNiFi to make use of NiFi 1.5 libraries and providing handling for the switch to RPG ports to make use of targetId where available in 1.2 encoded templates.

Updating some deprecated code usages.

Thank you for submitting a contribution to Apache NiFi - MiNiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [X] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [X] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [X] Is your initial contribution a single, squashed commit?

### For code changes:
- [X] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi-minifi folder?
- [X] Have you written or updated unit tests to verify your changes?
- [-] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? 
- [-] If applicable, have you updated the LICENSE file, including the main LICENSE file under minifi-assembly?
- [-] If applicable, have you updated the NOTICE file, including the main NOTICE file found under minifi-assembly?

### For documentation related changes:
- [-] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
