### PR TITLE
MINIFI-478 Fix broken OrderedProperties and OrderedPropertiesTest

### DIFF
--- a/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/util/OrderedProperties.java
+++ b/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/util/OrderedProperties.java
@@ -25,27 +25,36 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class OrderedProperties extends Properties {
     private final Map<String, String> textBeforeMap = new HashMap<>();
-    private final LinkedHashSet<Object> linkedHashSet = new LinkedHashSet<>();
+    private final LinkedHashSet<Object> orderedKeys = new LinkedHashSet<>();
 
     @Override
     public synchronized Object put(Object key, Object value) {
-        linkedHashSet.add(key);
+        orderedKeys.add(key);
         return super.put(key, value);
     }
 
     @Override
     public synchronized Enumeration<Object> keys() {
-        return Collections.enumeration(linkedHashSet.stream().filter(this::containsKey).collect(Collectors.toList()));
+        return Collections.enumeration(orderedKeys.stream().filter(this::containsKey).collect(Collectors.toList()));
+    }
+
+    @Override
+    public synchronized Set<Map.Entry<Object, Object>> entrySet() {
+        return orderedKeys.stream()
+                .map(k -> new AbstractMap.SimpleImmutableEntry<>(k, this.get(k)))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     public synchronized Object setProperty(String key, String value, String textBefore) {

--- a/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/OrderedPropertiesTest.java
+++ b/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/OrderedPropertiesTest.java
@@ -36,20 +36,26 @@ public class OrderedPropertiesTest {
         orderedProperties.setProperty("prop1", "origVal1");
         orderedProperties.setProperty("prop2", "val2", "#this is property 2");
         orderedProperties.setProperty("prop3", "val3");
+        orderedProperties.setProperty("prop4", "val4");
+        orderedProperties.setProperty("prop5", "val5", "#this is property 5");
+        orderedProperties.setProperty("prop3", "newVal3");
         orderedProperties.setProperty("prop1", "newVal1");
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         orderedProperties.store(byteArrayOutputStream, PROPERTIES_FILE_APACHE_2_0_LICENSE);
 
-        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(byteArrayOutputStream.toByteArray())));
+        try (BufferedReader actualReader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(byteArrayOutputStream.toByteArray())));
              BufferedReader expectedReader = new BufferedReader(new InputStreamReader(OrderedPropertiesTest.class.getClassLoader().getResourceAsStream("orderedPropertiesExpected.properties")))) {
             String expectedLine;
             while((expectedLine = expectedReader.readLine()) != null) {
-                String actualLine = bufferedReader.readLine();
+                String actualLine = actualReader.readLine();
+                // assertEquals(expectedLine, actualLine);
                 if (!"#Tue Feb 21 11:03:08 EST 2017".equals(expectedLine)) {
                     assertEquals(expectedLine, actualLine);
+                } else {
+                    System.out.println("Skipping timestamp comment line");
                 }
             }
-            assertNull(bufferedReader.readLine());
+            assertNull(actualReader.readLine());
         }
     }
 }

--- a/minifi-bootstrap/src/test/resources/orderedPropertiesExpected.properties
+++ b/minifi-bootstrap/src/test/resources/orderedPropertiesExpected.properties
@@ -18,4 +18,7 @@
 prop1=newVal1
 #this is property 2
 prop2=val2
-prop3=val3
+prop3=newVal3
+prop4=val4
+#this is property 5
+prop5=val5


### PR DESCRIPTION
This fix is not specific to a platform or Java version.

This test was previously passing by plain coincidence. Here's a more detailed explanation:
- The only ordered data structure in `OrderedProperties` was `linkedHashSet` happened to be updated but never read and therefore it was never consulted for reading properties in ordered manner, i.e. in the same order they were put/set.
- The expectation and the contract of `OrderedProperties` is that overridden `store(OutputStream out, String comments)` method stores properties in ordered manner. However, this doesn't happen without this PR.
- The order in which properties are stored does not depend on `keys()` method but `entrySet()` method as it can be witnessed along the following call path `OrderedProperties.store` -> `Properties.store` -> `Properties.store0` where the entries `(Ordered)Properties` are read via `entrySet()`. Without this PR the default `Properties entrySet()` implementation is used to read properties.
- The order in which properties are read in `Properties entrySet()` which is based on underelying `ConcurrentHashMap.entrySet()` where entries are **unordered**.
- The reason why `OrderedPropertiesTest` was ever passing (on earlier Java versions) is the combination of a small test data set - only three properties with specific property names and the hash function implementation within the underlying `ConcurrentHashMap.putVal`, that stored those property names in such a way that the corresponding `ConcurrentHashMap.entrySet()` returned them in order by coincidence. The fact that `OrderedProperties.sets()` and any order wasn't explicitely used was not realized by neither implementor nor anyone else by this same coincidence.
- Due to limitations of my current computer setup, I didn't bother to compare side-by-side the hash function implementations of `ConcurrentHashMap.putVal` across Java versions so this is left as an exercize to the reader. However, note that hash function implementations may change from Java version to version since their role is to provide statistically normalized data (i.e. hash key) distribution across a hash map without having to guarantee the same mapping from name to a hash map slot.


Thank you for submitting a contribution to Apache NiFi - MiNiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi-minifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under minifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under minifi-assembly?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
