### PR TITLE
MINIFI-516: Added bootstrap option to override processors ssl references to use m…

### DIFF
--- a/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/util/BootstrapTransformer.java
+++ b/minifi-bootstrap/src/main/java/org/apache/nifi/minifi/bootstrap/util/BootstrapTransformer.java
@@ -31,6 +31,7 @@ import static org.apache.nifi.minifi.commons.schema.common.BootstrapPropertyKeys
 import static org.apache.nifi.minifi.commons.schema.common.BootstrapPropertyKeys.BOOTSTRAP_PROVENANCE_REPORTING_KEYS;
 import static org.apache.nifi.minifi.commons.schema.common.BootstrapPropertyKeys.BOOTSTRAP_SECURITY_PROPERTY_KEYS;
 import static org.apache.nifi.minifi.commons.schema.common.BootstrapPropertyKeys.BOOTSTRAP_SENSITIVE_PROPERTY_KEYS;
+import static org.apache.nifi.minifi.commons.schema.common.BootstrapPropertyKeys.USE_PARENT_SSL;
 
 public class BootstrapTransformer {
 
@@ -86,6 +87,16 @@ public class BootstrapTransformer {
         }
 
         return provenanceReportingPropsOptional;
+    }
+
+    public static boolean processorSSLOverride(final Properties bootstrapProperties) {
+        boolean shouldOverride = false;
+
+        if (bootstrapProperties != null) {
+            shouldOverride = Boolean.parseBoolean(bootstrapProperties.getProperty(USE_PARENT_SSL));
+        }
+
+        return shouldOverride;
     }
 
 }

--- a/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/ConfigTransformerTest.java
+++ b/minifi-bootstrap/src/test/java/org/apache/nifi/minifi/bootstrap/util/ConfigTransformerTest.java
@@ -53,6 +53,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringBufferInputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
@@ -64,6 +65,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -463,6 +465,39 @@ public class ConfigTransformerTest {
         }
     }
 
+    @Test
+    public void checkSSLOverrides() throws Exception {
+        File inputFile = new File("./src/test/resources/MINIFI-516/config.yml");
+        final Properties bootstrapProperties = getTestBootstrapProperties("MINIFI-516/bootstrap.conf");
+        ConfigTransformer.transformConfigFile(new FileInputStream(inputFile), "./target/", bootstrapProperties);
+
+        // nifi.properties testing
+        File nifiPropertiesFile = new File("./target/nifi.properties");
+        assertTrue(nifiPropertiesFile.exists());
+        assertTrue(nifiPropertiesFile.canRead());
+
+        nifiPropertiesFile.deleteOnExit();
+
+        // flow.xml.gz testing
+        File flowXml = new File("./target/flow.xml.gz");
+        assertTrue(flowXml.exists());
+        assertTrue(flowXml.canRead());
+
+        String flow = loadFlowXML(new FileInputStream(flowXml));
+
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document xml = db.parse(new StringBufferInputStream(flow));
+
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        String result = xPath.evaluate("/flowController/rootGroup/processor/property[name = \"SSL Context Service\"]/value/text()", xml);
+
+        assertEquals(result, "SSL-Context-Service");
+
+        flowXml.deleteOnExit();
+
+    }
+
     public void testConfigFileTransform(String configFile) throws Exception {
         ConfigSchema configSchema = SchemaLoader.loadConfigSchemaFromYaml(ConfigTransformerTest.class.getClassLoader().getResourceAsStream(configFile));
 
@@ -664,4 +699,26 @@ public class ConfigTransformerTest {
             }
         }
     }
+
+    public static Properties getTestBootstrapProperties(final String fileName) throws IOException {
+        final Properties bootstrapProperties = new Properties();
+        try (final InputStream fis = ConfigTransformerTest.class.getClassLoader().getResourceAsStream(fileName)) {
+            bootstrapProperties.load(fis);
+        }
+        return bootstrapProperties;
+    }
+
+    public static String loadFlowXML(InputStream compressedData) throws IOException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        GZIPInputStream gzipInputStream = new GZIPInputStream(compressedData);
+
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = gzipInputStream.read(buffer)) != -1) {
+            byteArrayOutputStream.write(buffer, 0, len);
+        }
+
+        return byteArrayOutputStream.toString();
+    }
+
 }

--- a/minifi-bootstrap/src/test/resources/MINIFI-516/bootstrap.conf
+++ b/minifi-bootstrap/src/test/resources/MINIFI-516/bootstrap.conf
@@ -19,7 +19,7 @@
 java=java
 
 # Username to use when running MiNiFi. This value will be ignored on Windows.
-run.as=${minifi.run.as}
+run.as=
 
 # Configure where MiNiFi's lib and conf directories live
 # When running as a Windows service set full paths instead of relative paths
@@ -59,8 +59,8 @@ nifi.minifi.provenance.reporting.instance.url=
 nifi.minifi.provenance.reporting.batch.size=
 nifi.minifi.provenance.reporting.communications.timeout=
 
-# Ignore all processor SSL controller services and use parent minifi SSL instead
-nifi.minifi.flow.use.parent.ssl=false
+# Ignore custom SSL controller services and use parent minifi SSL
+nifi.minifi.flow.use.parent.ssl=true
 
 # Notifiers to use for the associated agent, comma separated list of class names
 #nifi.minifi.notifier.ingestors=org.apache.nifi.minifi.bootstrap.configuration.ingestors.FileChangeIngestor
@@ -108,8 +108,8 @@ nifi.minifi.flow.use.parent.ssl=false
 java.arg.1=-Dorg.apache.jasper.compiler.disablejsr199=true
 
 # JVM memory settings
-java.arg.2=-Xms${minifi.jvm.heap.mb}m
-java.arg.3=-Xmx${minifi.jvm.heap.mb}m
+java.arg.2=-Xms256m
+java.arg.3=-Xmx256m
 
 # Enable Remote Debugging
 #java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000

--- a/minifi-bootstrap/src/test/resources/MINIFI-516/config.yml
+++ b/minifi-bootstrap/src/test/resources/MINIFI-516/config.yml
@@ -1,0 +1,102 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the \"License\"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+MiNiFi Config Version: 3
+Flow Controller:
+  name: listenhttp-withssl
+  comment: ''
+Core Properties:
+  flow controller graceful shutdown period: 10 sec
+  flow service write delay interval: 500 ms
+  administrative yield duration: 30 sec
+  bored yield duration: 10 millis
+  max concurrent threads: 1
+  variable registry properties: ''
+FlowFile Repository:
+  partitions: 256
+  checkpoint interval: 2 mins
+  always sync: false
+  Swap:
+    threshold: 20000
+    in period: 5 sec
+    in threads: 1
+    out period: 5 sec
+    out threads: 4
+Content Repository:
+  content claim max appendable size: 10 MB
+  content claim max flow files: 100
+  always sync: false
+Provenance Repository:
+  provenance rollover time: 1 min
+  implementation: org.apache.nifi.provenance.MiNiFiPersistentProvenanceRepository
+Component Status Repository:
+  buffer size: 1440
+  snapshot frequency: 1 min
+Security Properties:
+  keystore: ''
+  keystore type: ''
+  keystore password: ''
+  key password: ''
+  truststore: ''
+  truststore type: ''
+  truststore password: ''
+  ssl protocol: ''
+  Sensitive Props:
+    key:
+    algorithm: PBEWITHMD5AND256BITAES-CBC-OPENSSL
+    provider: BC
+Processors:
+- id: d636b1bb-fdc7-3e7e-0000-000000000000
+  name: ListenHTTP
+  class: org.apache.nifi.processors.standard.ListenHTTP
+  max concurrent tasks: 1
+  scheduling strategy: TIMER_DRIVEN
+  scheduling period: 0 sec
+  penalization period: 30 sec
+  yield period: 1 sec
+  run duration nanos: 0
+  auto-terminated relationships list:
+  - success
+  Properties:
+    Authorized DN Pattern: .*
+    Base Path: contentListener
+    HTTP Headers to receive as Attributes (Regex): .*
+    Listening Port: '11223'
+    Max Data to Receive per Second:
+    Max Unconfirmed Flowfile Time: 60 secs
+    Return Code: '200'
+    SSL Context Service: c6e0b2ac-9fa8-3e31-0000-000000000000
+    multipart-read-buffer-size: 512 KB
+    multipart-request-max-size: 1 MB
+Controller Services:
+- id: c6e0b2ac-9fa8-3e31-0000-000000000000
+  name: CustomSSL
+  type: org.apache.nifi.ssl.StandardRestrictedSSLContextService
+  Properties:
+    Keystore Filename: /tmp/keystore.jks
+    Keystore Password:
+    Keystore Type: JKS
+    SSL Protocol:
+    Truststore Filename: /tmp/truststore.jks
+    Truststore Password:
+    Truststore Type: JKS
+    key-password:
+Process Groups: []
+Input Ports: []
+Output Ports: []
+Funnels: []
+Connections: []
+Remote Process Groups: []
+NiFi Properties Overrides: {}

--- a/minifi-commons/minifi-commons-schema/src/main/java/org/apache/nifi/minifi/commons/schema/common/BootstrapPropertyKeys.java
+++ b/minifi-commons/minifi-commons-schema/src/main/java/org/apache/nifi/minifi/commons/schema/common/BootstrapPropertyKeys.java
@@ -42,6 +42,8 @@ public class BootstrapPropertyKeys {
     public static final String STATUS_REPORTER_PROPERTY_PREFIX = "nifi.minifi.status.reporter";
     public static final String STATUS_REPORTER_COMPONENTS_KEY = STATUS_REPORTER_PROPERTY_PREFIX + ".components";
 
+    public static final String USE_PARENT_SSL = "nifi.minifi.flow.use.parent.ssl";
+
     public static final String SECURITY_KEYSTORE_KEY = "nifi.minifi.security.keystore";
     public static final String SECURITY_KEYSTORE_TYPE_KEY = "nifi.minifi.security.keystoreType";
     public static final String SECURITY_KEYSTORE_PASSWORD_KEY = "nifi.minifi.security.keystorePasswd";

--- a/minifi-docs/src/main/markdown/System_Admin_Guide.md
+++ b/minifi-docs/src/main/markdown/System_Admin_Guide.md
@@ -694,6 +694,14 @@ You can now install the MiNiFi service by running the `install-service.bat` scri
 
 The *minifi.exe* in MiNiFi `bin` directory is used to run MiNiFi Windows service. The bundled one is for 64 bit architecture and requires 64 bit JRE. If you have to use 32 bit JRE for some reason, you need to replace the *minifi.exe* file with the one for 32 bit to make MiNiFi service runs successfully. To do so, go to [Commons Daemon project download page](https://commons.apache.org/proper/commons-daemon/download_daemon.cgi), download the binary (e.g. _commons-daemon-1.1.0-bin.zip_), extract it and replace *bin/minifi.exe* by copying `commons-daemon-x.x.x-bin/prunsrv.exe` into MiNiFi `bin` directory as *minifi.exe* to overwrite the 64 bit exe with the 32 bit one.
 
+# Flow overriding with bootstrap.conf
+
+The following options can be set to override flow properties in the config.yml
+
+*bootstrap.conf Property*         | *Description*
+----------------------------------|--------------------
+`nifi.minifi.flow.use.parent.ssl` | When set to true, all processors will reference the MiNiFi parent SSL controller service defined in the security properties, instead of custom controller services.
+
 # Example Config File
 
 Below are two example config YAML files. The first tails the *minifi-app.log* and sends the tailed log and provenance data back to a secure instance of NiFi. The second uses a series of processors to tail the app log, routes off only lines that contain "WriteAheadFlowFileRepository" and puts it as a file in the "./" directory.


### PR DESCRIPTION
…inifi parent ssl instead

When using a ingestor to deploy flows to MiNiFi, processors using SSL contexts don't start up as the sensitive properties are not passed along in the NiFi templates.
A user should be able to set a boolean in the bootstrap.conf to tell MiNiFi to ignore any custom SSL contexts in the config.yml, and repoint to the parent SSL called "SSL-Context-Service" instead.

Thank you for submitting a contribution to Apache NiFi - MiNiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi-minifi folder?
- [x] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under minifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under minifi-assembly?

### For documentation related changes:
- [x] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
