### PR TITLE
MINIFI-517: Added /opt/minifi/minifi-current symlink

### DIFF
--- a/minifi-docker/dockerhub/Dockerfile
+++ b/minifi-docker/dockerhub/Dockerfile
@@ -43,7 +43,7 @@ RUN curl -fSL $MINIFI_BINARY_URL -o $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION-bin.
 	&& rm $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION-bin.tar.gz \
 	&& ln -s $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION $MINIFI_HOME
 
-RUN chown -R minifi:minifi $MINIFI_HOME
+RUN chown -R -L minifi:minifi $MINIFI_HOME
 
 USER minifi
 

--- a/minifi-docker/dockerhub/Dockerfile
+++ b/minifi-docker/dockerhub/Dockerfile
@@ -24,13 +24,13 @@ ARG GID=1000
 ARG MINIFI_VERSION=0.5.0
 
 ENV MINIFI_BASE_DIR /opt/minifi
-ENV MINIFI_HOME $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION
+ENV MINIFI_HOME $MINIFI_BASE_DIR/minifi-current
 ENV MINIFI_BINARY_URL https://archive.apache.org/dist/nifi/minifi/$MINIFI_VERSION/minifi-$MINIFI_VERSION-bin.tar.gz
 
 # Setup MiNiFi user
 RUN addgroup -g $GID minifi || groupmod -n minifi `getent group $GID | cut -d: -f1`
 RUN adduser -S -H -G minifi minifi
-RUN mkdir -p $MINIFI_HOME
+RUN mkdir -p $MINIFI_BASE_DIR
 
 RUN apk --no-cache add curl
 
@@ -40,7 +40,8 @@ ADD sh/ ${MINIFI_BASE_DIR}/scripts/
 RUN curl -fSL $MINIFI_BINARY_URL -o $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION-bin.tar.gz \
 	&& echo "$(curl $MINIFI_BINARY_URL.sha256) *$MINIFI_BASE_DIR/minifi-$MINIFI_VERSION-bin.tar.gz" | sha256sum -c - \
 	&& tar -xvzf $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION-bin.tar.gz -C $MINIFI_BASE_DIR \
-	&& rm $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION-bin.tar.gz
+	&& rm $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION-bin.tar.gz \
+	&& ln -s $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION $MINIFI_HOME
 
 RUN chown -R minifi:minifi $MINIFI_HOME
 

--- a/minifi-docker/dockermaven/Dockerfile
+++ b/minifi-docker/dockermaven/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir -p $MINIFI_BASE_DIR
 
 ADD $MINIFI_BINARY $MINIFI_BASE_DIR
 RUN ln -s $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION $MINIFI_HOME
-RUN chown -R minifi:minifi $MINIFI_HOME
+RUN chown -R -L minifi:minifi $MINIFI_HOME
 
 USER minifi
 

--- a/minifi-docker/dockermaven/Dockerfile
+++ b/minifi-docker/dockermaven/Dockerfile
@@ -26,14 +26,15 @@ ARG MINIFI_VERSION
 ARG MINIFI_BINARY
 
 ENV MINIFI_BASE_DIR /opt/minifi
-ENV MINIFI_HOME $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION
+ENV MINIFI_HOME $MINIFI_BASE_DIR/minifi-current
 
 # Setup MiNiFi user
 RUN addgroup -g $GID minifi || groupmod -n minifi `getent group $GID | cut -d: -f1`
 RUN adduser -S -H -G minifi minifi
-RUN mkdir -p $MINIFI_HOME
+RUN mkdir -p $MINIFI_BASE_DIR
 
 ADD $MINIFI_BINARY $MINIFI_BASE_DIR
+RUN ln -s $MINIFI_BASE_DIR/minifi-$MINIFI_VERSION $MINIFI_HOME
 RUN chown -R minifi:minifi $MINIFI_HOME
 
 USER minifi


### PR DESCRIPTION
To prevent path breakages when the MiNiFi version changes, add a symlink in the Dockerfile to /opt/minifi/minifi-current - similar to the NiFi docker image.

Thank you for submitting a contribution to Apache NiFi - MiNiFi.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced 
     in the commit message?

- [x] Does your PR title start with MINIFI-XXXX where XXXX is the JIRA number you are trying to resolve? Pay particular attention to the hyphen "-" character.

- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?

- [x] Is your initial contribution a single, squashed commit?

### For code changes:
- [ ] Have you ensured that the full suite of tests is executed via mvn -Pcontrib-check clean install at the root nifi-minifi folder?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? 
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file under minifi-assembly?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file found under minifi-assembly?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
